### PR TITLE
Check for binary attributes on LDAPUser wrap

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,10 @@
 Change log
 ==========
 
-3,1 (unreleased)
+3.1 (unreleased)
 ----------------
 
+- don't encode attributes when wrapping an LDAPUser if they are flagged binary
 
 3.0 (2018-05-21)
 ----------------

--- a/Products/LDAPUserFolder/LDAPUser.py
+++ b/Products/LDAPUserFolder/LDAPUser.py
@@ -27,6 +27,7 @@ from Products.LDAPUserFolder.utils import _verifyUnicode
 
 class NonexistingUser:
     """Fake user we can use in our negative cache."""
+
     def __init__(self):
         self.birth = DateTime()
 
@@ -44,7 +45,7 @@ class LDAPUser(BasicUser):
 
     def __init__(self, uid, name, password, roles, domains, user_dn,
                  user_attrs, mapped_attrs, multivalued_attrs=(),
-                 ldap_groups=()):
+                 binary_attrs=(), ldap_groups=()):
         """ Instantiate a new LDAPUser object """
         self._properties = {}
         self.id = _verifyUnicode(uid)
@@ -65,7 +66,8 @@ class LDAPUser(BasicUser):
             else:
                 prop = user_attrs.get(key, [None])[0]
 
-            if isinstance(prop, str) and key != 'objectGUID':
+            if isinstance(prop, str) and key != 'objectGUID' and \
+               key not in binary_attrs:
                 prop = _verifyUnicode(prop)
 
             self._properties[key] = prop

--- a/Products/LDAPUserFolder/LDAPUserFolder.py
+++ b/Products/LDAPUserFolder/LDAPUserFolder.py
@@ -87,9 +87,9 @@ class LDAPUserFolder(BasicUserFolder):
     #################################################################
 
     manage_options = (
-        ({'label': 'Configure',	'action': 'manage_main',
+        ({'label': 'Configure', 'action': 'manage_main',
           'help': ('LDAPUserFolder', 'Configure.stx')},
-         {'label': 'LDAP Servers',	'action': 'manage_servers',
+         {'label': 'LDAP Servers',  'action': 'manage_servers',
           'help': ('LDAPUserFolder', 'Servers.stx')},
          {'label': 'LDAP Schema', 'action': 'manage_ldapschema',
           'help': ('LDAPUserFolder', 'Schema.stx')},
@@ -680,7 +680,7 @@ class LDAPUserFolder(BasicUserFolder):
                 login_name = login_name[0]
         elif len(login_name) == 0:
             msg = 'getUserByAttr: "%s" has no "%s" (Login) value!' % (
-                    user_dn, self._login_attr)
+                user_dn, self._login_attr)
             logger.debug(msg)
             self._cache('negative').set(negative_cache_key, NonexistingUser())
             return None
@@ -689,7 +689,7 @@ class LDAPUserFolder(BasicUserFolder):
             uid = uid[0]
         elif len(uid) == 0:
             msg = 'getUserByAttr: "%s" has no "%s" (UID Attribute) value!' % (
-                    user_dn, self._uid_attr)
+                user_dn, self._uid_attr)
             logger.debug(msg)
             self._cache('negative').set(negative_cache_key, NonexistingUser())
             return None
@@ -697,6 +697,7 @@ class LDAPUserFolder(BasicUserFolder):
         user_obj = LDAPUser(uid, login_name, pwd or 'undef', user_roles or [],
                             [], user_dn, user_attrs, self.getMappedUserAttrs(),
                             self.getMultivaluedUserAttrs(),
+                            self.getBinaryUserAttrs(),
                             ldap_groups=ldap_groups)
 
         if cache:
@@ -1214,7 +1215,7 @@ class LDAPUserFolder(BasicUserFolder):
 
         if REQUEST:
             msg = 'Added LDAP group to Zope role mapping: %s -> %s' % (
-                    group_name, role_name)
+                group_name, role_name)
             return self.manage_grouprecords(manage_tabs_message=msg)
 
     security.declareProtected(manage_users, 'manage_deleteGroupMappings')
@@ -1232,7 +1233,7 @@ class LDAPUserFolder(BasicUserFolder):
 
         if REQUEST:
             msg = 'Deleted LDAP group to Zope role mapping for: %s' % (
-                    ', '.join(group_names))
+                ', '.join(group_names))
             return self.manage_grouprecords(manage_tabs_message=msg)
 
     def _mapRoles(self, groups):

--- a/Products/LDAPUserFolder/tests/config.py
+++ b/Products/LDAPUserFolder/tests/config.py
@@ -37,8 +37,10 @@ alternates = {'title': 'LDAPUserFolder', 'server': 'localhost:1389',
 user = {'cn': 'test', 'sn': 'User', 'mail': 'joe@blow.com',
         'givenName': 'G\xc3\xbcnther', 'objectClasses': ['top', 'person'],
         'user_pw': 'mypass', 'confirm_pw': 'mypass', 'user_roles': ['Manager'],
+        'jpegPhoto': 'dont-\xc3\xbcncode-me',
         'mapped_attrs': {'objectClasses': 'Objektklassen'},
         'multivalued_attrs': ['objectClasses'],
+        'binary_attrs': ['jpegPhoto'],
         'ldap_groups': ['Group1', 'Group2']}
 
 manager_user = {'cn': 'mgr', 'sn': 'Manager', 'givenName': 'Test',


### PR DESCRIPTION
When wrapping an LDAPUser, binary attributes are no longer encoded. This helps if jpegPhotos are retrieved from LDAP